### PR TITLE
feat(BUX-116): tx 'Outputs' field for admin dashboard and omitempty for OutputValue

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -29,7 +29,9 @@ type Transaction struct {
 	// TotalValue is a total input value.
 	TotalValue uint64 `json:"total_value"`
 	// OutputValue is a total output value.
-	OutputValue int64 `json:"output_value"`
+	OutputValue int64 `json:"output_value,omitempty"`
+	// Outputs represents all bux-transaction outputs. Will be shown only for admin.
+	Outputs map[string]int64 `json:"outputs,omitempty"`
 	// Status is a transaction status.
 	Status string `json:"status"`
 	// TransactionDirection is a transaction direction (inbound/outbound).


### PR DESCRIPTION
Necessary for next change in bux-console.
At the moment admin sees OutputValue as 0 in the bux-console.
OutputValue is a value that should be "calculated" and calculation result is different for the recipient and the sender, and it can be actually shown only for the recipient and the sender. Admin is neither sender nor receiver and he will be shown a map of all bux-outputs(xpub as key, satos as value) instead of outputvalue.